### PR TITLE
(feat) Teleport to Objective additional blips support

### DIFF
--- a/src/util/blip.cpp
+++ b/src/util/blip.cpp
@@ -56,6 +56,8 @@ namespace big::blip
 			return true;
 		if (get_objective_location_iteration(location, {BlipIcons::RADAR_LEVEL}, {BlipColors::Green, BlipColors::Blue}))
 			return true;
+		if (get_objective_location_iteration(location, {BlipIcons::RADAR_SPORTS_CAR}, {BlipColors::Blue}))
+			return true;
 
 		static const auto blip_icons = {BlipIcons::RADAR_OBJECTIVE_BLUE, BlipIcons::RADAR_OBJECTIVE_GREEN, BlipIcons::RADAR_OBJECTIVE_RED, BlipIcons::RADAR_OBJECTIVE_YELLOW, BlipIcons::RADAR_CRATEDROP, BlipIcons::RADAR_TARGET_A, BlipIcons::RADAR_TARGET_B, BlipIcons::RADAR_TARGET_C, BlipIcons::RADAR_TARGET_D, BlipIcons::RADAR_TARGET_E, BlipIcons::RADAR_TARGET_F, BlipIcons::RADAR_TARGET_G, BlipIcons::RADAR_TARGET_H, BlipIcons::RADAR_SM_CARGO, BlipIcons::RADAR_BAT_CARGO};
 		for (const auto icon : blip_icons)


### PR DESCRIPTION
Included a check for the RADAR_SPORTS_CAR icon with blue color in the objective location iteration logic to improve blip detection for possibility to quick teleport when doing CEO Vehicle Cargo sourcing mission