### PR TITLE
fix: fix CAN_REGISTER_MISSION_DOORS crash

### DIFF
--- a/src/byte_patch_manager.cpp
+++ b/src/byte_patch_manager.cpp
@@ -66,7 +66,7 @@ namespace big
 		memory::byte_patch::make(g_pointers->m_gta.m_script_vm_patch_6.add(6).as<uint16_t*>(), 0x9090)->apply();
 
 		// Patch script network check
-		memory::byte_patch::make(g_pointers->m_gta.m_model_spawn_bypass, std::vector{0x90, 0x90})->apply(); // this is no longer integrity checked
+		//memory::byte_patch::make(g_pointers->m_gta.m_model_spawn_bypass, std::vector{0x90, 0x90})->apply(); // this is no longer integrity checked
 
 		// Increase Start Get Presence Attributes limit from 32 to 100
 		memory::byte_patch::make(g_pointers->m_sc.m_num_handles_patch, std::vector{0x64})->apply();

--- a/src/script_mgr.cpp
+++ b/src/script_mgr.cpp
@@ -24,7 +24,11 @@ namespace big
 
 	void script_mgr::tick()
 	{
-		gta_util::execute_as_script("main_persistent"_J, std::mem_fn(&script_mgr::tick_internal), this);
+		auto thread = gta_util::find_script_thread("freemode"_J);
+		if (!thread)
+			thread = gta_util::find_script_thread("main_persistent"_J);
+		if (thread)
+			gta_util::execute_as_script(thread, std::mem_fn(&script_mgr::tick_internal), this);
 	}
 
 	void script_mgr::ensure_main_fiber()


### PR DESCRIPTION
In b3717, `carmod_shop` introduced a case where `CAN_REGISTER_MISSION_DOORS` is called in SP. Normally, this native early exits in SP because `CTheScripts::GetHandlerCheckNetwork` returns `false`; however, our `m_model_spawn_bypass` patch force this check to pass. This allows the native to proceed and eventually dereference the object manager—which is `nullptr` at that moment—leading to an exception.

This PR makes our code run inside `freemode` (a networked script) when it is available. This way, we don't need to patch anything at all and thus prevent the exception.